### PR TITLE
Direct questions

### DIFF
--- a/src/controller/ratings_controller.py
+++ b/src/controller/ratings_controller.py
@@ -45,5 +45,6 @@ class RatingsController():
         self.ratings_view.set_progress(progress)
 
     def register_rating(self, ratings: tuple, answers: dict):
-        write_ratings(ratings, self.user_id, self.recording.id)
+        result = check_answers(user_answers = answers, correct_answers = self.correct_answers)
+        write_ratings(ratings = ratings, answers = result, user_id = self.user_id, recording_id = self.recording.id)
         self.load_next_recording()

--- a/src/controller/ratings_controller.py
+++ b/src/controller/ratings_controller.py
@@ -1,5 +1,5 @@
 from src.view.app_view import AppView
-from src.model.ratings_model import filter_recordings, get_next_recording_id, get_recording_filename, write_ratings, get_progress
+from src.model.ratings_model import filter_recordings, get_next_recording, get_recording_filename, write_ratings, get_progress, get_correct_answers_from_recording, check_answers
 from src.model.audio_player_model import get_sound_duration, play_sound
 from os import path
 from src import AUDIO_FOLDER
@@ -18,22 +18,21 @@ class RatingsController():
         self.load_next_recording()
 
     def load_next_recording(self):
-        self.recording_id = get_next_recording_id(user_id = self.user_id)
-        if self.recording_id == None:
+        self.recording = get_next_recording(user_id = self.user_id)
+        if self.recording == None:
             self.app_controller.end_test()
             return
-        self.recording_filename = get_recording_filename(id = self.recording_id)
+        self.recording_filename = get_recording_filename(id = self.recording.id)
+        self.correct_answers = get_correct_answers_from_recording(recording = self.recording) # Facing Angle / Movement
         self.play_next_recording()
 
     def play_next_recording(self):
-        #TODO: remove next line when the correct audios will be added
-        # self.recording_filename = r'C:\Users\labsticc\Desktop\pink_noise.wav'
         file = path.join(AUDIO_FOLDER, self.recording_filename)
 
         try:            
             recording_duration = get_sound_duration(path = file)
             play_sound(file)
-            self.ratings_view.reset_sliders()
+            self.ratings_view.reset(list(self.correct_answers.keys()))
             self.ratings_view.disable_validate_button(recording_duration)
             self.ratings_view.display_soundfile_name(soundfile = path.basename(file))
             self.update_progress()
@@ -45,6 +44,6 @@ class RatingsController():
         progress = get_progress(self.user_id)
         self.ratings_view.set_progress(progress)
 
-    def register_rating(self, ratings: tuple):
-        write_ratings(ratings, self.user_id, self.recording_id)
+    def register_rating(self, ratings: tuple, answers: dict):
+        write_ratings(ratings, self.user_id, self.recording.id)
         self.load_next_recording()

--- a/src/model/models.py
+++ b/src/model/models.py
@@ -73,13 +73,17 @@ class Rating(Base):
     plausibility = Column('plausibility', FLOAT)
     source_width = Column('source_width', FLOAT)
     timbre = Column('timbre', FLOAT)
+    angle = Column('angle', BOOLEAN)
+    movement = Column('movement', BOOLEAN)
 
-    def __init__(self, plausibility: float, source_width: float, timbre: float, user_id: int, recording_id: int):
+    def __init__(self, plausibility: float, source_width: float, timbre: float, user_id: int, recording_id: int, angle: bool, movement: bool):
         self.plausibility = plausibility
         self.source_width = source_width
         self.user_id = user_id
         self.recording_id = recording_id
         self.timbre = timbre
+        self.angle = angle
+        self.movement = movement
 
 class User(Base):
     __tablename__ = 'users'

--- a/src/model/queries.py
+++ b/src/model/queries.py
@@ -104,7 +104,7 @@ def get_nb_recordings(session) -> int:
 
 def get_unrated_recordings(user_id: int, session) -> list:
     rated_recordings_subquery = select(Rating.recording_id).filter(Rating.user_id == user_id)
-    unrated_recordings = session.query(Recording.id).where(and_(Recording.id.in_(_recordings_in_session), ~Recording.id.in_(rated_recordings_subquery))).all()
+    unrated_recordings = session.query(Recording).where(and_(Recording.id.in_(_recordings_in_session), ~Recording.id.in_(rated_recordings_subquery))).all()
     return unrated_recordings
 
 def get_recording(id, session) -> Recording:

--- a/src/model/ratings_model.py
+++ b/src/model/ratings_model.py
@@ -26,9 +26,11 @@ def get_recording_filename(id: int) -> str:
         recording = get_recording(id, session)
         return recording.audio_file
     
-def write_ratings(ratings: tuple, user_id: int, recording_id: int):
+def write_ratings(ratings: tuple, answers: dict, user_id: int, recording_id: int):
     timbre, source_width, plausibility = ratings
-    r = Rating(plausibility = plausibility, source_width = source_width, timbre = timbre, user_id = user_id, recording_id = recording_id)
+    angle = answers['angle']
+    movement = answers['movement']
+    r = Rating(plausibility = plausibility, source_width = source_width, timbre = timbre, angle = angle, movement = movement, user_id = user_id, recording_id = recording_id)
     with Session() as session:
         write_to_db(r, session)
         session.commit()

--- a/src/model/ratings_model.py
+++ b/src/model/ratings_model.py
@@ -1,7 +1,7 @@
 from src.model import Session
-from src.model.queries import filter_recordings_in_session, get_unrated_recordings, get_recording, write_ratings as write_to_db, get_nb_completed_ratings, get_nb_recordings
+from src.model.queries import filter_recordings_in_session, get_unrated_recordings, get_recording, write_ratings as write_to_db, get_nb_completed_ratings, get_nb_recordings, get_conditions_from_recording
 from random import choice
-from src.model.models import Rating
+from src.model.models import Rating, Recording, Condition
 
 def filter_recordings(variables: dict) -> None:
     rooms = variables['Room']
@@ -13,13 +13,13 @@ def filter_recordings(variables: dict) -> None:
     
     filter_recordings_in_session(rooms, distances, angles, movements, sources, amplitudes)
 
-def get_next_recording_id(user_id: int) -> int:
+def get_next_recording(user_id: int) -> Recording:
     with Session() as session:
         unrated_recordings = get_unrated_recordings(user_id, session)
         if not unrated_recordings:
             return None
         else:
-            return choice(unrated_recordings).id
+            return choice(unrated_recordings)
         
 def get_recording_filename(id: int) -> str:
     with Session() as session:
@@ -38,3 +38,14 @@ def get_progress(user_id: int):
         nb_rated_recordings = get_nb_completed_ratings(user_id, session)
         nb_total_recordings = get_nb_recordings(session)
     return nb_rated_recordings / nb_total_recordings
+
+def get_correct_answers_from_recording(recording: Recording) -> dict:
+    with Session() as session:
+        conditions: Condition = get_conditions_from_recording(recording = recording, session = session)
+    return {'angle': conditions.angle, 'movement': conditions.movement}
+
+def check_answers(user_answers: dict, correct_answers: dict) -> dict:
+    answers = {}
+    for key, value in user_answers.items():
+        answers[key] = value == correct_answers[key]
+    return answers

--- a/src/view/ratings_view.py
+++ b/src/view/ratings_view.py
@@ -32,12 +32,20 @@ class DirectQuestion(ctk.CTkFrame):
         self.answer_callback = answer_callback
         self.answer = None
         self.correct_answer = None
-        
-        self.choice_1 = ctk.CTkButton(master = self, text = self.choices[0], command = self.set_choice(choice = 0))
-        self.choice_1.grid_configure(row = 0, column = 0, padx = (10,0), pady = 10, sticky = 'nw')
 
-        self.choice_2 = ctk.CTkButton(master = self, text = self.choices[1], command = self.set_choice(choice = 1))
-        self.choice_2.grid_configure(row = 0, column = 1, padx = 10, pady = 10, sticky = 'ne')
+        self.columnconfigure((0,3), weight = 1)
+        
+        self.choice_1 = ctk.CTkButton(master = self, text = self.choices[0])
+        self.choice_1.grid_configure(row = 0, column = 1, padx = (10,0), pady = 10, sticky = 'nw')
+
+        self.choice_2 = ctk.CTkButton(master = self, text = self.choices[1])
+        self.choice_2.grid_configure(row = 0, column = 2, padx = 10, pady = 10, sticky = 'ne')
+
+        self.choice_buttons = (self.choice_1, self.choice_2)
+
+        for index, button in enumerate(self.choice_buttons):
+            button.configure(command = lambda index = index: self.set_choice(index), hover = False)
+            button.configure(fg_color = 'grey25')
 
     def set_correct_answer(self, answer: int):
         self.correct_answer = answer
@@ -46,6 +54,11 @@ class DirectQuestion(ctk.CTkFrame):
     def set_choice(self, choice: int):
         self.answer = choice == self.correct_answer
         self.answer_callback()
+        
+        not_chosen = (choice-1)**2
+
+        self.choice_buttons[choice].configure(fg_color = '#00966b')
+        self.choice_buttons[not_chosen].configure(fg_color = 'grey25')
         
 
 class RatingsView(ctk.CTkFrame):

--- a/src/view/ratings_view.py
+++ b/src/view/ratings_view.py
@@ -26,15 +26,17 @@ class Rating(ctk.CTkFrame):
 
 class DirectQuestion(ctk.CTkFrame):
     def __init__(self, master, choices: tuple, answer_callback: callable):
+        super().__init__(master)
 
         self.choices = choices
         self.answer_callback = answer_callback
         self.answer = None
+        self.correct_answer = None
         
-        self.choice_1 = ctk.CTkButton(master = self, text = self.choices[0], command = self.set_choice(0))
+        self.choice_1 = ctk.CTkButton(master = self, text = self.choices[0], command = self.set_choice(choice = 0))
         self.choice_1.grid_configure(row = 0, column = 0, padx = (10,0), pady = 10, sticky = 'nw')
 
-        self.choice_2 = ctk.CTkButton(master = self, text = self.choices[1], command = self.set_choice(1))
+        self.choice_2 = ctk.CTkButton(master = self, text = self.choices[1], command = self.set_choice(choice = 1))
         self.choice_2.grid_configure(row = 0, column = 1, padx = 10, pady = 10, sticky = 'ne')
 
     def set_correct_answer(self, answer: int):
@@ -69,14 +71,23 @@ class RatingsView(ctk.CTkFrame):
         self.plausibility_rating = Rating(master = self, attribute_name = 'Plausibilité')
         self.plausibility_rating.grid_configure(row = 1, column = 2, padx = 20, pady = (10,0), sticky = 'new')
 
+        self.angle_direct_question = DirectQuestion(master = self, choices = ('Frontal', 'Latéral'), answer_callback = self.check_all_direct_questions_answered)
+        self.angle_direct_question.grid_configure(row = 2, column = 0, columnspan = 3, padx = 0, pady = (20,0), sticky = 'new')
+        
+        self.movement_direct_question = DirectQuestion(master = self, choices = ('Statique', 'Dynamique'), answer_callback = self.check_all_direct_questions_answered)
+        self.movement_direct_question.grid_configure(row = 3, column = 0, columnspan = 3, padx = 0, pady = (20,0), sticky = 'new')
+
         self.validate_btn = ctk.CTkButton(master = self, width = 50, text = 'Valider', command = self.validate)
-        self.validate_btn.grid_configure(row = 2, column = 0, columnspan = 3, padx = 0, pady = (20,0), sticky = 'new')
+        self.validate_btn.grid_configure(row = 4, column = 0, columnspan = 3, padx = 0, pady = (20,0), sticky = 'new')
 
         self.progress_bar = ctk.CTkProgressBar(master = self)
-        self.progress_bar.grid_configure(row = 3, column = 0, columnspan = 3, padx = 0, pady = (10,0), sticky = 'new')
+        self.progress_bar.grid_configure(row = 5, column = 0, columnspan = 3, padx = 0, pady = (10,0), sticky = 'new')
 
         self.text_display = ctk.CTkButton(master = self, textvariable = self.text_variable, text_color = '#8d2929', fg_color = 'gray20', hover = False, image = self.copy_text_image, command = self.copy_text, width = 300)
-        self.text_display.grid_configure(row = 4, column = 0, columnspan = 3, padx = 0, pady = (10,0), sticky = 'sew')
+        self.text_display.grid_configure(row = 6, column = 0, columnspan = 3, padx = 0, pady = (10,0), sticky = 'sew')
+
+    def check_all_direct_questions_answered(self):
+        pass
 
     def validate(self):
         if self.validate_btn.cget('state') == 'disabled':

--- a/src/view/ratings_view.py
+++ b/src/view/ratings_view.py
@@ -23,6 +23,27 @@ class Rating(ctk.CTkFrame):
     
     def reset(self):
         self.slider.set(.5)
+
+class DirectQuestion(ctk.CTkFrame):
+    def __init__(self, master, choices: tuple, answer_callback: callable):
+
+        self.choices = choices
+        self.answer_callback = answer_callback
+        self.answer = None
+        
+        self.choice_1 = ctk.CTkButton(master = self, text = self.choices[0], command = self.set_choice(0))
+        self.choice_1.grid_configure(row = 0, column = 0, padx = (10,0), pady = 10, sticky = 'nw')
+
+        self.choice_2 = ctk.CTkButton(master = self, text = self.choices[1], command = self.set_choice(1))
+        self.choice_2.grid_configure(row = 0, column = 1, padx = 10, pady = 10, sticky = 'ne')
+
+    def set_correct_answer(self, answer: int):
+        self.correct_answer = answer
+        self.answer = None
+
+    def set_choice(self, choice: int):
+        self.answer = choice == self.correct_answer
+        self.answer_callback()
         
 
 class RatingsView(ctk.CTkFrame):


### PR DESCRIPTION
The user should now answer 2 direct questions for each sound: whether the source faces towards them or to the side, and whether the source is static or dynamic.

Users shouldn't be able to validate if they didn't answer both direct questions.

User answers are stored in the ratings table. The corresponding columns (`angle` and `movement`) store `1` for a correct answer and `0` for an incorrect answer.

![image](https://github.com/user-attachments/assets/dcddbc54-45b8-4662-9273-58dc4fb6c9e7)
